### PR TITLE
add daily term

### DIFF
--- a/2026/july-term.md
+++ b/2026/july-term.md
@@ -2288,3 +2288,202 @@ NO pod can run as root(3/11)
 ```
 
 ---
+
+day - 21
+
+## Green Unit Tests
+
+### Definition:
+
+"Green Unit Tests" is a critical concept about the false sense of security that comes from seeing all tests passing (green) — when the tests themselves may not actually be validating the right things. A green test suite tells you that your code works correctly for the inputs you thought of when writing the tests. It tells you nothing about the inputs you didn't think of — which is exactly what will hit you in production.
+
+The term was popularized by a June 2026 HackerNoon article describing how a tool (postman2pytest) shipped as "Production/Stable" v1.0 with a fully green test suite — only for a fuzzer (property-based testing) to immediately find 5 categories of bugs that the green tests had completely missed.
+
+═══════════════════════════════════════════════════════════════
+  THE COMFORT BLANKET
+═══════════════════════════════════════════════════════════════
+
+  WHAT DEVELOPERS SEE:
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │   🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢                     │
+  │   ✅ All 47 tests passing!                              │
+  │   ✅ Code coverage: 93%                                 │
+  │   ✅ CI pipeline: green                                 │
+  │   ✅ Ship it! 🚀                                        │
+  │                                                         │
+  │   "Production/Stable v1.0"                              │
+  │                                                         │
+  └─────────────────────────────────────────────────────────┘
+
+  WHAT THE GREEN TESTS ACTUALLY COVER:
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │   Inputs tested:          The ones the AUTHOR            │
+  │                           wrote while coding             │
+  │                                                         │
+  │   Blind spots:            EVERY OTHER INPUT              │
+  │                           • Corrupted files             │
+  │                           • User-generated exports      │
+  │                           • Deeply nested data          │
+  │                           • Unexpected data types       │
+  │                           • Truncated payloads          │
+  │                           • Edge cases from OTHER       │
+  │                             people's data               │
+  │                                                         │
+  └─────────────────────────────────────────────────────────┘
+
+  THE GAP:
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │   "If your tool reads a file someone else made, your    │
+    │    unit tests are a comfort blanket. The input you       │
+    │    did not write is the one that finds you in            │
+    │    production."                                         │
+    │                                                         │
+    │            — Mikhail Golikov, HackerNoon, June 2026      │
+    │                                                         │
+    └─────────────────────────────────────────────────────────┘
+
+### Example:
+
+A visual walkthrough of how a tool with a 100% green test suite shipped to production — and immediately failed on real-world input.
+
+```
+A developer builds postman2pytest — a tool that converts Postman API collections (JSON files) into pytest test suites. The test suite is 100% green. The tool is released as v1.0 "Production/Stable."
+═══════════════════════════════════════════════════════════════
+  THE GREEN TEST SUITE (What the developer tested)
+═══════════════════════════════════════════════════════════════
+
+  Test Input                    Expected Output              Result
+  ────────────────────────────────────────────────────────────────
+
+  collection.json (valid)       pytest test file             🟢 PASS
+  (3 endpoints, proper          with 3 test functions
+   formatting, good data)
+
+  collection.json (valid)       pytest test file             🟢 PASS
+  (1 endpoint, simple GET)
+
+  collection.json (valid)       pytest test file             🟢 PASS
+  (with auth headers)
+
+  All 47 tests: 🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢 🟢 ... 🟢 🟢 🟢
+
+  ✅ Coverage: 93%
+  ✅ CI: Green
+  ✅ Release: "Production/Stable v1.0" 🚀
+  ═══════════════════════════════════════════════════════════════
+    WHAT THE FUZZER FOUND (Real user inputs, 5 bugs in minutes)
+  ═══════════════════════════════════════════════════════════════
+  
+    A fuzzer (property-based testing with Hypothesis) generates
+    random JSON and feeds it to the parser. The rule is simple:
+  
+    "Feed it any well-formed JSON. It should return a list of
+     parsed tests OR raise a clear error. NEVER a raw stack trace."
+  
+    ┌─────────────────────────────────────────────────────────┐
+    │                                                         │
+    │  BUG #1: Top-level is a LIST instead of object          │
+    │  ────────────────────────────────────────────            │
+    │                                                         │
+    │  Input:                                                  │
+    │  [{"item": {"request": ...}}]                           │
+    │  (Postman normally sends {"collections": [...]},         │
+    │   but some export tools wrap it in an array)            │
+    │                                                         │
+    │  What happened: AttributeError with raw stack trace     │
+    │  Expected: "This file is a list, expected a dict."      │
+    │                                                         │
+    │  ❌ Green tests missed this because the developer        │
+    │     never tested with a list as the top-level value.    │
+    │                                                         │
+    ├─────────────────────────────────────────────────────────┤
+    │                                                         │
+    │  BUG #2: "info" block is a STRING instead of dict       │
+    │  ──────────────────────────────────────────────          │
+    │                                                         │
+    │  Input:                                                  │
+    │  {"info": "my collection", "item": [...]}               │
+    │  (Some tools export the info field as a string          │
+    │   instead of a structured object)                       │
+      │                                                         │
+      │  What happened: AttributeError with raw stack trace     │
+      │  Expected: "'info' field should be a dict, got string"  │
+      │                                                         │
+      │  ❌ Green tests always had info as a dict.               │
+      │                                                         │
+      ├─────────────────────────────────────────────────────────┤
+      │                                                         │
+      │  BUG #3: Item is a bare NUMBER instead of dict          │
+      │  ──────────────────────────────────────────────          │
+      │                                                         │
+      │  Input:                                                  │
+      │  {"collection": {"item": [42]}}                         │
+      │  (Corrupted export: an item that should be a dict       │
+      │   is just a number)                                     │
+      │                                                         │
+      │  What happened: TypeError with raw stack trace          │
+      │  Expected: "Item #0 is a number, expected a dict"       │
+      │                                                         │
+      │  ❌ Green tests never had a non-dict item.               │
+      │                                                         │
+      ├─────────────────────────────────────────────────────────┤
+      │                                                         │
+      │  BUG #4: Deeply nested folder recursion                 │
+      │  ───────────────────────────────────────────             │
+      │                                                         │
+      │  Input:                                                  │
+      │  {"item": [{"item": [{"item": [{"item": [...]}]}]}]     │
+      │  (Extremely deep nesting — possible in real exports)    │
+      │                                                         │
+      │  What happened: RecursionError with raw stack trace      │
+        │  Expected: "Folder nesting exceeds maximum depth (50)"  │
+        │                                                         │
+        │  ❌ Green tests had 2 levels of nesting.                 │
+        │                                                         │
+        ├─────────────────────────────────────────────────────────┤
+        │                                                         │
+        │  BUG #5: JSON so deep that json.loads blows the stack   │
+        │  ──────────────────────────────────────────────          │
+        │                                                         │
+        │  Input:                                                  │
+        │  A JSON file with 10,000 nested brackets                │
+        │                                                         │
+        │  What happened: RecursionError (Python's json parser     │
+        │                 itself crashed, not the tool)            │
+        │  Expected: "This file is nested too deeply to parse"    │
+        │                                                         │
+        │  ❌ Green tests never considered the JSON ITSELF         │
+        │     could be too deep for the parser.                   │
+        │                                                         │
+        └─────────────────────────────────────────────────────────┘
+      
+      
+      ═══════════════════════════════════════════════════════════════
+        THE ROOT CAUSE: Same-Blind-Spot Bias
+      ═══════════════════════════════════════════════════════════════
+      
+        The developer wrote the parser AND the tests
+        in the SAME coding session.
+      
+        ┌─────────────────────────────────────────────────────────┐
+        │                                                         │
+        │  When you write code, you imagine valid inputs.         │
+        │  When you write tests for that code, you imagine        │
+        │  the SAME valid inputs.                                 │
+        │                                                         │
+        │  Result: Tests confirm your assumptions, not            │
+          │          challenge them.                                │
+          │                                                         │
+          │  The fuzzer has no assumptions. It generates            │
+          │  everything — including what you didn't imagine.        │
+          │                                                         │
+          └─────────────────────────────────────────────────────────┘
+```
+
+---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Green Unit Tests” section to the July 2026 term materials.
  * Explains how passing test suites can create false confidence and leave important blind spots.
  * Includes a practical example showing how property-based testing can uncover missed bug categories.
  * Introduces “Same-Blind-Spot Bias” as a root cause of inadequate test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->