### PR TITLE
add daily term

### DIFF
--- a/2026/august-term.md
+++ b/2026/august-term.md
@@ -841,3 +841,79 @@ STEP 3: TF-IDF = TF × IDF — combine both scores
 ```
 
 ---
+
+day - 11
+
+## WebMCP (Web Model Context Protocol)
+
+### Definition:
+
+WebMCP is a proposed web standard (from Chrome and the W3C Web Machine Learning community group) that lets websites expose structured, machine-readable tools for AI agents — so an agent knows exactly how to interact with a page instead of guessing. It extends the Model Context Protocol (MCP) from the server side to the client side, inside the browser, treating each web page as an "in-page MCP server" that implements its tools in JavaScript and HTML rather than on a backend.
+
+The core problem WebMCP solves is actuation reliability. When an AI agent browses a website, it normally "reads" the page and tries to figure out what each button, field, and link does by looking at it — then simulates clicks and typing (actuation). This is slow, error-prone, and leaves every step open to interpretation. WebMCP removes the guessing: the website declares the purpose of its features, and the agent uses them correctly.
+TRADITIONAL AGENT ACTUATION vs. WEBMCP:
+═══════════════════════════════════════════════════════════════
+
+  WITHOUT WEBMCP (Agent has to GUESS):
+  ──────────────────────────────────────────────────────────
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │  Agent reads the page visually:                         │
+  │                                                         │
+  │  "[text box] — is this a search field? a name field?    │
+  │    a booking date field?"                               │
+  │  "[button] — does this 'Continue' checkout? or 'Clear'  │
+  │    the form?"                                            │
+  │  "[calendar] — what date format does it want?"          │
+  │                                                         │
+  │  Agent GUESSES → clicks → wrong field → retries         │
+  │  → misinterprets → fails or does the wrong thing        │
+  │                                                         │
+  │  Result: Slow, unreliable, multi-step, error-prone.     │
+  │  The agent is "flying blind" — interpreting UI like     │
+  │  a human reading a foreign language.                    │
+  │                                                         │
+  └─────────────────────────────────────────────────────────┘
+
+  WITH WEBMCP (The page DECLARES its purpose):
+  ──────────────────────────────────────────────────────────
+
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │  Website registers tools the agent can CALL directly:   │
+  │                                                         │
+  │  Tool: "bookAppointment"                                │
+  │    input: { date: string, time: string,                │
+  │             service: string }                           │
+  │    output: { confirmationId: string }                   │
+  │                                                         │
+    │  Tool: "searchProducts"                                 │
+    │    input: { query: string }                             │
+    │                                                         │
+    │  Tool: "selectInsurancePlan"                            │
+    │    input: { plan: string }                              │
+    │                                                         │
+    │  Agent CALLS the tool with the right inputs → the page  │
+    │  executes it correctly, visibly, in the browser.        │
+    │                                                         │
+    │  Result: Fast, reliable, single-step, accurate.         │
+    │  The agent uses the page's OWN logic — no guessing.     │
+    │                                                         │
+    └─────────────────────────────────────────────────────────┘
+
+### Example:
+
+```
+Analogy — The Restaurant With a Menu vs. The Restaurant That Reads Minds 🤵
+
+Imagine you're a VIP guest (the AI agent) at a restaurant, and you need to order a complicated multi-course meal.
+
+**Without WebMCP** is like a restaurant where you have to figure out the menu by reading the waiters' minds: you look at the kitchen, guess which dish the chef can make, point at random plates, and hope. If you guess wrong, you order something you didn't want. It's slow, frustrating, and often wrong.
+
+**With WebMCP** is like a restaurant that hands you a **structured, clearly-labeled menu** with exact descriptions: "Dish 1: grilled salmon, specify cooking level; Dish 2: pasta, specify sauce and portion." You read the menu, place your order precisely, and the kitchen (using its own recipes) produces exactly what you asked for.
+
+WebMCP is that structured menu for AI agents: instead of the agent guessing what each part of the website does, the website hands the agent a clear, labeled list of "here's what I can do, here's exactly what inputs I need."
+```
+
+---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an overview of WebMCP, a browser-side standard for exposing structured website tools to AI agents.
  - Explained how declared inputs and outputs enable direct tool invocation instead of UI-based guessing.
  - Included practical examples covering appointment booking, product search, insurance selection, and structured menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->